### PR TITLE
Implemented display of air canvas onto React Interface rather than separate OpenCV window.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+venv/

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "miniproject",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://127.0.0.1:5000/",
   "dependencies": {
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",

--- a/src/Pages/Home/Home.jsx
+++ b/src/Pages/Home/Home.jsx
@@ -1,25 +1,19 @@
 import React, { useState } from 'react';
-import axios from 'axios';
+import Canvas from "../../components/Canvas/Canvas";
 
 function Home() {
-  const [executionresult, setExecutionResult] = useState('');
+  const [showCanvas, setShowCanvas] = useState(false);
 
   const handleButtonClick = async () => {
-    try {
-      const response = await axios.post('http://localhost:5000/api/run-python');
-      setExecutionResult(response.data.success ? response.data.output : response.data.error);
-    } catch (error) {
-      console.error('Error running Python code:', error);
-    }
+    setShowCanvas(!showCanvas);
   };
 
   return (
     <div>
       <h1>Meet Link</h1>
-      <button onClick={handleButtonClick}>Run Python Code</button>
+      <button onClick={handleButtonClick}>{showCanvas ? 'Stop Canvas' : 'Show Canvas'}</button>
       <div>
-        <strong>Result:</strong>
-        <pre>{executionresult}</pre>
+        {showCanvas && <Canvas />}
       </div>
     </div>
   );

--- a/src/components/Canvas/Canvas.css
+++ b/src/components/Canvas/Canvas.css
@@ -1,0 +1,12 @@
+.Canvas {
+    border-radius: 15px;
+    width: 48%;
+    height: auto;
+    border: solid 1px;
+}
+
+.CanvasContainer {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+}

--- a/src/components/Canvas/Canvas.jsx
+++ b/src/components/Canvas/Canvas.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import "./Canvas.css";
+
+const Canvas = () => {
+    return (
+        <div class="CanvasContainer">
+            <img class="Canvas" src={'/video?type=camera'} alt="webcam" />
+            <img class="Canvas" src={'/video?type=blank'} alt="webcam" />
+        </div>
+    );
+};
+
+export default Canvas;

--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -1,4 +1,3 @@
-
 * {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
Changes:
1. Updated app.py to have support for livestreaming the video capture/output to the 'video/' URL. There are two types of video streaming output,
    a) CameraOverlayDisplay: Here the camera stream with the lines/drawing overlapping over the camera, is being displayed.
    b) BlankCanvasDisplay: Here the actual blank paint-like canvas with the drawings is displayed.
    These two modes can be accessed using the URL modifications: '/video?type=camera' or '/video?type=blank'.
2. Added a component named Canvas which displays 2 live video feeds, each one is explained earlier.
3. A reference.py file is kept along with app.py to refer earlier version (Feels a bit unneccessary).
4. Added 'venv/' in .gitignore.
5. Updated Footer.css to have relative position, for the time being to see the images being displayed. (This behaviour needs to be modified later)